### PR TITLE
fixes build problem on node 8

### DIFF
--- a/src/deferredtask.h
+++ b/src/deferredtask.h
@@ -2,7 +2,7 @@
 
 #include <node.h>
 #include <uv.h>
-
+#include <string>
 namespace exawallet {
 
 // only dynamic allocated


### PR DESCRIPTION
seems node8 lacks <string> header inclusion

```  CXX(target) Release/obj.target/monero/src/deferredtask.o
In file included from ../src/deferredtask.cc:1:
../src/deferredtask.h:30:17: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    std::string errorString;
                ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/iosfwd:193:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
../src/deferredtask.cc:14:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    resolver.Get(isolate)->Resolve(isolate->GetCurrentContext(), value);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/deferredtask.cc:29:39: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    deferred->errorString = deferred->doWork();
                                      ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/iosfwd:193:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;```